### PR TITLE
Check that users have added their identities to ssh agent

### DIFF
--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+
+ssh-add -L > /dev/null
+if [ ! $? -eq 0 ]
+then
+    RED_C='\033[0;31m'
+    RESET_C='\033[0m'
+    echo -e "${RED_C}SSH Agent doesn't have any identities, consider running:${RESET_C}"
+    echo "    ssh-add"
+fi
+
 set -eo pipefail
 
 IMAGE_NAME=uber/ssh-agent-forward:latest


### PR DESCRIPTION
And give users a hint for how to resolve their issues.

_this would have saved me a bunch of time_

Before `pinata-ssh-forward` would fail silently with no hints if you had not added your ssh identities to the ssh-agent.

now:
``` bash
$ ssh-add -D # removes all identities from ssh-agent
All identities removed.
$ ./pinata-ssh-forward.sh
SSH Agent doesn't have any identities, consider running:
    ssh-add
$ ssh-add
Identity added: /Users/drusu/.ssh/id_rsa (/Users/drusu/.ssh/id_rsa)
$ ./pinata-ssh-forward.sh
....<continues as usual>....
```