### PR TITLE
Pass --init to "docker run" so it can use tini

### DIFF
--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -16,6 +16,7 @@ docker volume create --name "${VOLUME_NAME}"
 
 docker run \
   --name "${CONTAINER_NAME}" \
+  --init \
   -e AUTHORIZED_KEYS="${AUTHORIZED_KEYS}" \
   -v ${VOLUME_NAME}:/ssh-agent \
   -d \


### PR DESCRIPTION
"docker run" is failing because it cannot find tini in /usr/local/bin

Since tini is now included by default in docker, we can pass in the --init flag to ensure it's used.

See https://github.com/krallin/tini#using-tini for details